### PR TITLE
Fixes issue #10 for Samsung Internet Browser.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "plastic-image",
   "description": "iron-image extension supporting srcset and lazy loading",
   "main": "plastic-image.html",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "MIT",
   "keywords": [
     "polymer",

--- a/plastic-image.html
+++ b/plastic-image.html
@@ -522,7 +522,7 @@ the `fallbackSrc` / `fallback-src` attribute instead.
              * @private
              */
             _lazyLoadCallback(e) {
-                if (e.isIntersecting && this._lazyLoadPending) {
+                if (this._lazyLoadPending && (e.isIntersecting || e.intersectionRatio >= 0.001)) {
                     this._lazyLoadPending = false;
                 }
             }


### PR DESCRIPTION
Fixes [Lazy-load not working in Samsung browser #10](https://github.com/mlisook/plastic-image/issues/10) by using `intersectionRatio` as a fallback for `isIntersecting`.