### PR TITLE
iss 36 polyfill scroll woes on Safari

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "plastic-image",
   "description": "iron-image extension supporting srcset and lazy loading",
   "main": "plastic-image.html",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "license": "MIT",
   "keywords": [
     "polymer",

--- a/plastic-image.html
+++ b/plastic-image.html
@@ -856,11 +856,9 @@ the `fallbackSrc` / `fallback-src` attribute instead.
                         };
                         if (polyfilled) {
                             // issue 23 - Edge does not reliably dispatch scroll events
-                            let uaparser = new UAParser();
-                            let uapResult = uaparser.getResult();
-                            if (uapResult && uapResult.browser && (uapResult.browser.name == "Edge" || uapResult.browser.name == "IE")) {
+                            // issue 36 - Safari iOS does not reliably get scroll events with iron-scroll-target
+                            //            At this point all pollyfilled browsers need polling :(
                                 window.plasticImageIntersectionObserver.observer.POLL_INTERVAL = 120;
-                            }
                         }
                     }
                     // observe this element

--- a/test/lazy.html
+++ b/test/lazy.html
@@ -34,7 +34,7 @@
     <script>
         describe('plastic-image lazy load', () => {
             let testFixture1, findSrcsetEntry, i51, wp01, hugeSpacer;
-            
+
             beforeEach(() => {
                 testFixture1 = fixture('lazyFixture');
                 window.scroll(0, 0);
@@ -75,6 +75,34 @@
                             setTimeout(() => {
                                 resolve(wp01._lazyLoadPending);
                             }, 250);
+                        })
+                        .then((llp) => {
+                            expect(llp).to.eql(false); // lazy load is no longer pending
+                        });
+                })
+            });
+            context('layout 2', () => {
+                it('should not be loading before layout changes 2', () => {
+                    return new Promise((resolve, reject) => {
+                            // this hack is for browsers that could be loading the polyfill
+                            // which creates a delay before the intersection observer is created.
+                            setTimeout(() => {
+                                resolve(wp01._lazyLoadPending);
+                            }, 250);
+                        })
+                        .then((llp) => {
+                            expect(llp).to.eql(true); // lazy load is pending
+                        });
+                });
+                it('should be loading after layout changes 2', () => {
+                    hugeSpacer.style.height = "10px";
+                    return new Promise((resolve, reject) => {
+                            // this hack is for browsers using the polyfill and polling
+                            // which creates a delay before the intersection observer picks up
+                            // layout changes
+                            setTimeout(() => {
+                                resolve(wp01._lazyLoadPending);
+                            }, 200);
                         })
                         .then((llp) => {
                             expect(llp).to.eql(false); // lazy load is no longer pending


### PR DESCRIPTION
mobile safari scroll events don't issue reliably to IntersectionObserver polyfill when iron-scroll-target-behavior is in use.