### PR TITLE
fix iss 38, flexible webp detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,21 @@ the best fit webp image.  If the browser does not support webp, the control will
 
 Webp images are typically significantly smaller than JPG or PNG so it can represent a decrease in network traffic.
 
-There are no flags or attributes to enable this support.  Just include webp along with non webp images in the srcset to take advantage.  
+There are no flags to enable this support.  Just include webp along with non webp images in the srcset to take advantage.
+
+### How Webp Images are Detected in the srcset
+
+`plastic-image` checks for webp images using a regular expression. The default regex is `/\.webp$/i` (i.e. the url ends with `.webp`). This may not work for you if you are using url parameters or if for any other reason the url doesn't end with `.webp`.  You can modify the regex used to suit your url scheme by setting the `webpRegex` property: 
+```HTML
+<plastic-image id="wp01" webp-regex="wp=yes" lazy-load preload fade use-element-dim sizing="contain" ...
+```
+(matches `wp=yes` case insensitive anywhere in the url)
+
+You can supply just the matching string, as above, or the complete regex including modifiers such as:
+```HTML
+<plastic-image id="wp01" webp-regex="/[\?&]wp=yes/i" lazy-load preload fade use-element-dim sizing="contain" ...
+```
+(matches `?wp=yes` or `&wp=yes` case insensitive anywhere in the url)
 
 ### Example Webp
 

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "plastic-image",
   "description": "iron-image extension supporting srcset and lazy loading",
   "main": "plastic-image.html",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "license": "MIT",
   "keywords": [
     "polymer",

--- a/plastic-image.html
+++ b/plastic-image.html
@@ -192,6 +192,13 @@ the `fallbackSrc` / `fallback-src` attribute instead.
                         value: /.+\.webp$/i
                     },
                     /**
+                     * override default webp detection regex
+                     */
+                    webpRegex: {
+                        type: String,
+                        observer: "_webpRegexObserver"
+                    },
+                    /**
                      * Indicates that the srcset string has at least one webp image
                      * @private
                      */
@@ -204,7 +211,7 @@ the `fallbackSrc` / `fallback-src` attribute instead.
 
             static get observers() {
                 return [
-                    '_doImageSelectionObserver(fallbackSrc, srcset, delayLoad, _lazyLoadPending)',
+                    '_doImageSelectionObserver(fallbackSrc, srcset, delayLoad, _lazyLoadPending, _webpRegex)',
                     '_cleanupWillChange(fade, loaded, src)'
                 ]
             }
@@ -858,7 +865,7 @@ the `fallbackSrc` / `fallback-src` attribute instead.
                             // issue 23 - Edge does not reliably dispatch scroll events
                             // issue 36 - Safari iOS does not reliably get scroll events with iron-scroll-target
                             //            At this point all pollyfilled browsers need polling :(
-                                window.plasticImageIntersectionObserver.observer.POLL_INTERVAL = 120;
+                            window.plasticImageIntersectionObserver.observer.POLL_INTERVAL = 120;
                         }
                     }
                     // observe this element
@@ -905,6 +912,7 @@ the `fallbackSrc` / `fallback-src` attribute instead.
                     } else {
                         // if webp has previously been detected, use the prior detection
                         if (window.plasticImageWebp) {
+                            this._supportsWebp = window.plasticImageWebp.supports;
                             resolve(this._filterWebp(srcArray, window.plasticImageWebp.supports));
                         } else {
                             // support has not been previously detected so
@@ -948,6 +956,30 @@ the `fallbackSrc` / `fallback-src` attribute instead.
                 return srcArray.filter((srcitem) => {
                     return this._webpRegex.test(srcitem.url) === supports;
                 })
+            }
+            /**
+             * Observer for this.webpRegex which provides the element consumer
+             * api access to modify the webp detection regex. This function
+             * handle a change to webpRegex
+             * by applying the change to _webpRegex
+             */
+            _webpRegexObserver(n, o) {
+                if (n) {
+                    // webpRegex can be either a matching string, e.g.
+                    // "\.webp\?foo=bar" or it can be a full regex expression, e.g.
+                    // "/\.webp\?foo=bar/i" i.e. with the enclosing "/" and modifiers, if any.
+                    let regParts = n.match(/^\/(.*?)\/([gim]*)$/);
+                    if (regParts) {
+                        this._webpRegex = new RegExp(regParts[1], regParts[2]);
+                    } else {
+                        // if the string did not have delimiters
+                        // create a regex with just the pattern and ignore case
+                        this._webpRegex = new RegExp(n, "i");
+                    }
+                } else {
+                    // reset to default webp detection
+                    this._webpRegex = /.+\.webp$/i;
+                }
             }
         }
 

--- a/test/webp.html
+++ b/test/webp.html
@@ -23,6 +23,18 @@
             <plastic-image id="wp01" preload fade use-element-dim sizing="contain" style="height: 200px; width: 300px;" srcset="images/20160827_055746-150x150.jpg 150w,images/20160827-055746-150x150.webp 150w,images/20160827_055746-300x169.jpg 300w,images/20160827-055746-300x169.webp 300w,images/20160827_055746-768x432.jpg 768w,images/20160827-055746-768x432.webp 768w"
                 placeholder="data: image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD//gA7Q1JFQVRPUjogZ2QtanBlZyB2MS4wICh1c2luZyBJSkcgSlBFRyB2OTApLCBxdWFsaXR5ID0gODIK/9sAQwAGBAQFBAQGBQUFBgYGBwkOCQkICAkSDQ0KDhUSFhYVEhQUFxohHBcYHxkUFB0nHR8iIyUlJRYcKSwoJCshJCUk/9sAQwEGBgYJCAkRCQkRJBgUGCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQk/8AAEQgACAAOAwEiAAIRAQMRAf/EAB8AAAEFAQEBAQEBAAAAAAAAAAABAgMEBQYHCAkKC//EALUQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+v/EAB8BAAMBAQEBAQEBAQEAAAAAAAABAgMEBQYHCAkKC//EALURAAIBAgQEAwQHBQQEAAECdwABAgMRBAUhMQYSQVEHYXETIjKBCBRCkaGxwQkjM1LwFWJy0QoWJDThJfEXGBkaJicoKSo1Njc4OTpDREVGR0hJSlNUVVZXWFlaY2RlZmdoaWpzdHV2d3h5eoKDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uLj5OXm5+jp6vLz9PX29/j5+v/aAAwDAQACEQMRAD8A8p8A/EK70MfZbvVJ0tAuF8qJGcHju3br611Go/EPS7pkY+K7tMDBV7ZevrxHRRXdSzKtTVt/W/8AmeRUwVOc3fr6f5H/2Q==">
             </plastic-image>
+            <plastic-image id="wp02" preload fade use-element-dim sizing="contain" style="height: 200px; width: 300px;" srcset="images/20160827_055746-150x150.jpg 150w,images/20160827-055746-150x150.webp?foo=bar 150w,images/20160827_055746-300x169.jpg 300w,images/20160827-055746-300x169.webp?foo=bar 300w,images/20160827_055746-768x432.jpg 768w,images/20160827-055746-768x432.webp?foo=bar 768w"
+                placeholder="data: image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD//gA7Q1JFQVRPUjogZ2QtanBlZyB2MS4wICh1c2luZyBJSkcgSlBFRyB2OTApLCBxdWFsaXR5ID0gODIK/9sAQwAGBAQFBAQGBQUFBgYGBwkOCQkICAkSDQ0KDhUSFhYVEhQUFxohHBcYHxkUFB0nHR8iIyUlJRYcKSwoJCshJCUk/9sAQwEGBgYJCAkRCQkRJBgUGCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQk/8AAEQgACAAOAwEiAAIRAQMRAf/EAB8AAAEFAQEBAQEBAAAAAAAAAAABAgMEBQYHCAkKC//EALUQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+v/EAB8BAAMBAQEBAQEBAQEAAAAAAAABAgMEBQYHCAkKC//EALURAAIBAgQEAwQHBQQEAAECdwABAgMRBAUhMQYSQVEHYXETIjKBCBRCkaGxwQkjM1LwFWJy0QoWJDThJfEXGBkaJicoKSo1Njc4OTpDREVGR0hJSlNUVVZXWFlaY2RlZmdoaWpzdHV2d3h5eoKDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uLj5OXm5+jp6vLz9PX29/j5+v/aAAwDAQACEQMRAD8A8p8A/EK70MfZbvVJ0tAuF8qJGcHju3br611Go/EPS7pkY+K7tMDBV7ZevrxHRRXdSzKtTVt/W/8AmeRUwVOc3fr6f5H/2Q=="
+                webp-regex="foo=bar">
+            </plastic-image>
+            <plastic-image id="wp03" preload fade use-element-dim sizing="contain" style="height: 200px; width: 300px;" srcset="images/20160827_055746-150x150.jpg 150w,images/20160827-055746-150x150.webp?foo=bar 150w,images/20160827_055746-300x169.jpg 300w,images/20160827-055746-300x169.webP?fOO=BAR 300w,images/20160827_055746-768x432.jpg 768w,images/20160827-055746-768x432.webp?foo=bar 768w"
+                placeholder="data: image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD//gA7Q1JFQVRPUjogZ2QtanBlZyB2MS4wICh1c2luZyBJSkcgSlBFRyB2OTApLCBxdWFsaXR5ID0gODIK/9sAQwAGBAQFBAQGBQUFBgYGBwkOCQkICAkSDQ0KDhUSFhYVEhQUFxohHBcYHxkUFB0nHR8iIyUlJRYcKSwoJCshJCUk/9sAQwEGBgYJCAkRCQkRJBgUGCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQk/8AAEQgACAAOAwEiAAIRAQMRAf/EAB8AAAEFAQEBAQEBAAAAAAAAAAABAgMEBQYHCAkKC//EALUQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+v/EAB8BAAMBAQEBAQEBAQEAAAAAAAABAgMEBQYHCAkKC//EALURAAIBAgQEAwQHBQQEAAECdwABAgMRBAUhMQYSQVEHYXETIjKBCBRCkaGxwQkjM1LwFWJy0QoWJDThJfEXGBkaJicoKSo1Njc4OTpDREVGR0hJSlNUVVZXWFlaY2RlZmdoaWpzdHV2d3h5eoKDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uLj5OXm5+jp6vLz9PX29/j5+v/aAAwDAQACEQMRAD8A8p8A/EK70MfZbvVJ0tAuF8qJGcHju3br611Go/EPS7pkY+K7tMDBV7ZevrxHRRXdSzKtTVt/W/8AmeRUwVOc3fr6f5H/2Q=="
+                webp-regex="/ebp\?Foo=/i">
+            </plastic-image>
+            <plastic-image id="wp04" preload fade use-element-dim sizing="contain" style="height: 200px; width: 300px;" srcset="images/20160827_055746-150x150.jpg 150w,images/20160827-055746-150x150.webp?foo=bar 150w,images/20160827_055746-300x169.jpg 300w,images/20160827-055746-300x169.webP?fOO=BAR 300w,images/20160827_055746-768x432.jpg 768w,images/20160827-055746-768x432.webp?foo=bar 768w"
+                placeholder="data: image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD//gA7Q1JFQVRPUjogZ2QtanBlZyB2MS4wICh1c2luZyBJSkcgSlBFRyB2OTApLCBxdWFsaXR5ID0gODIK/9sAQwAGBAQFBAQGBQUFBgYGBwkOCQkICAkSDQ0KDhUSFhYVEhQUFxohHBcYHxkUFB0nHR8iIyUlJRYcKSwoJCshJCUk/9sAQwEGBgYJCAkRCQkRJBgUGCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQk/8AAEQgACAAOAwEiAAIRAQMRAf/EAB8AAAEFAQEBAQEBAAAAAAAAAAABAgMEBQYHCAkKC//EALUQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+v/EAB8BAAMBAQEBAQEBAQEAAAAAAAABAgMEBQYHCAkKC//EALURAAIBAgQEAwQHBQQEAAECdwABAgMRBAUhMQYSQVEHYXETIjKBCBRCkaGxwQkjM1LwFWJy0QoWJDThJfEXGBkaJicoKSo1Njc4OTpDREVGR0hJSlNUVVZXWFlaY2RlZmdoaWpzdHV2d3h5eoKDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uLj5OXm5+jp6vLz9PX29/j5+v/aAAwDAQACEQMRAD8A8p8A/EK70MfZbvVJ0tAuF8qJGcHju3br611Go/EPS7pkY+K7tMDBV7ZevrxHRRXdSzKtTVt/W/8AmeRUwVOc3fr6f5H/2Q=="
+                webp-regex="/doesnotmatch\?Foo=/i">
+            </plastic-image>
             <plastic-image id="i51" preload fade placeholder="data: image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD//gA7Q1JFQVRPUjogZ2QtanBlZyB2MS4wICh1c2luZyBJSkcgSlBFRyB2OTApLCBxdWFsaXR5ID0gODIK/9sAQwAGBAQFBAQGBQUFBgYGBwkOCQkICAkSDQ0KDhUSFhYVEhQUFxohHBcYHxkUFB0nHR8iIyUlJRYcKSwoJCshJCUk/9sAQwEGBgYJCAkRCQkRJBgUGCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQk/8AAEQgAEwAOAwEiAAIRAQMRAf/EAB8AAAEFAQEBAQEBAAAAAAAAAAABAgMEBQYHCAkKC//EALUQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+v/EAB8BAAMBAQEBAQEBAQEAAAAAAAABAgMEBQYHCAkKC//EALURAAIBAgQEAwQHBQQEAAECdwABAgMRBAUhMQYSQVEHYXETIjKBCBRCkaGxwQkjM1LwFWJy0QoWJDThJfEXGBkaJicoKSo1Njc4OTpDREVGR0hJSlNUVVZXWFlaY2RlZmdoaWpzdHV2d3h5eoKDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uLj5OXm5+jp6vLz9PX29/j5+v/aAAwDAQACEQMRAD8AxPGPj298dxz7khtLS0ZQtsgH3+hZmwCTyeOg/PPNPHJcRK6OqKPlLMOCfQV2WgfCSyiguRcX91G1xgsUfHIwcjnnn1/lXNeM9L07QGX7PcSxRysAkpA3MAMEc4PXnjjn6V5FSuqsr3uz01SlSprSx6Rqc8senyMjspWMkY7HHWuO1u2gvr7N1BFNsQBQ6Ahclug6dqKK5aO5310f/9k="
                 sizing="contain" srcset="images/IMG_20170426_112820-150x150.jpg 150w, images/IMG_20170426_112820-225x300.jpg 225w"
                 style="height: 400px; width: 400px;">
@@ -69,7 +81,13 @@
                 i50 = document.querySelector('#i50');
                 i49 = document.querySelector('#i49');
                 wp01 = document.querySelector('#wp01');
+                wp02 = document.querySelector('#wp02');
+                wp03 = document.querySelector('#wp03');
+                wp04 = document.querySelector('#wp04');
                 wp01.assignImgSrc();
+                wp02.assignImgSrc();
+                wp03.assignImgSrc();
+                wp04.assignImgSrc();
                 i51.assignImgSrc();
                 i50.assignImgSrc();
                 i49.assignImgSrc();
@@ -78,13 +96,29 @@
 
                 it('should determine support if srcset has webp', () => {
                     let webpRegex = /.+\.webp$/;
-                    let srcarr = wp01.srcsetParse(wp01.srcset);
-                    return wp01._checkBrowserWebpSupport(srcarr)
+                    wp01.assignImgSrc();
+                    return wp01._checkBrowserWebpSupport(wp01.srcsetParse(wp01.srcset))
                         .then((arr) => {
                             expect(wp01._supportsWebp).to.not.be.a('undefined');
                             expect(arr.length).to.eql(3);
                             let c = arr.filter((item) => {
                                 return webpRegex.test(item.url) == wp01._supportsWebp;
+                            });
+
+                            expect(c.length).to.eql(3);
+                        });
+
+                });
+
+                it('should determine support if srcset has webp and custom regex', () => {
+                    let webpRegex = wp02._webpRegex;
+                    wp02.assignImgSrc();
+                    return wp02._checkBrowserWebpSupport(wp02.srcsetParse(wp02.srcset))
+                        .then((arr) => {
+                            expect(wp02._supportsWebp).to.not.be.a('undefined');
+                            expect(arr.length).to.eql(3);
+                            let c = arr.filter((item) => {
+                                return webpRegex.test(item.url) == wp02._supportsWebp;
                             });
 
                             expect(c.length).to.eql(3);
@@ -114,10 +148,20 @@
 
                 it('should know if srcset has webp images', () => {
                     expect(wp01._hasWebp).to.eql(true);
+                    expect(wp02._hasWebp).to.eql(true);
+                    expect(wp03._hasWebp).to.eql(true);
+                    expect(wp04._hasWebp).to.eql(false);
                     expect(i51._hasWebp).to.eql(false);
                     expect(i50._hasWebp).to.eql(false);
                     expect(i49._hasWebp).to.eql(false);
                 });
+
+                it('should allow change to webp regex', () => {
+                    expect(wp04._hasWebp).to.eql(false);
+                    wp04.webpRegex = "foo=";
+                    wp04.assignImgSrc();
+                    expect(wp04._hasWebp).to.eql(true);
+                })
 
             });
 


### PR DESCRIPTION
Adds a new property, `webpRegex` (attribute `webp-regex`) which can be used to override the regex test pattern used to detect webp images in the srcset.

Updated the webp portion of the tests to include this feature.