### PR TITLE
static get rqd for importPath

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
     "name": "plastic-image",
     "description": "iron-image extension supporting srcset and lazy loading",
     "main": "plastic-image.html",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "license": "MIT",
     "keywords": [
       "polymer",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plastic-image",
   "flat": true,
-  "version": "3.0.0",
+  "version": "3.0.2",
   "description": "iron-image extension supporting srcset and lazy loading",
   "keywords": [
     "polymer",

--- a/plastic-image.js
+++ b/plastic-image.js
@@ -105,6 +105,8 @@ class PlasticImage extends customElements.get('iron-image') {
         }
         return window.PlasticImageTemplate;
     }
+    static get importMeta() { return import.meta; }
+
     static get properties() {
         return {
             /**


### PR DESCRIPTION
Per the [Polymer 3.0 upgrade guide](https://www.polymer-project.org/3.0/docs/upgrade) a static getter is required if importPath is used:

If you use the importPath property in you element's template, you must add a static importMeta getter:
```js
class extends PolymerElement {
  static get importMeta() { return import.meta; }
}
```
